### PR TITLE
make frontend Repositories use rails api

### DIFF
--- a/app/javascript/components/pages/Repositories.jsx
+++ b/app/javascript/components/pages/Repositories.jsx
@@ -18,15 +18,14 @@ export default function Repositories(props){
     useEffect(() => {
         if (!isLoaded && state.isLoggedIn) {
             const access_token = state.user.access_token;
-            const url = "https://api.github.com/orgs/" 
-                + orgName + "/repos";
+            const url = "/api/orgs/" + orgName + "/repos";
             axios.get(url, {
                 headers: {
                     'Authorization': `token ${access_token}`
                 }
             })
             .then((res) => {
-                setRepoData(res.data);
+                setRepoData(res.data['repositories']);
                 setIsLoaded(true);
             })
             .catch((error) => {


### PR DESCRIPTION
Simple - in the Repositories React component, replace the API call to Github with an API call to the app's Rails back-end