### PR TITLE
Include code alerts in api responses

### DIFF
--- a/app/controllers/api/orgs_controller.rb
+++ b/app/controllers/api/orgs_controller.rb
@@ -1,5 +1,16 @@
 class Api::OrgsController < ApplicationController
   def index
-    render json: @user.organizations, status: :ok
+    orgs = @user.organizations
+    orgs_json = JSON.parse(orgs.to_json())
+
+    # add code_alerts_exist boolean field to organizations json
+    orgs.zip(orgs_json).each { |org, org_json|
+      org_json["code_alerts_exist"] = false
+      org.repositories.each { |repo|
+        org_json["code_alerts_exist"] |= (repo.code_alerts.size() > 0)
+      }
+    }
+
+    render json: orgs_json, status: :ok
   end
 end

--- a/app/controllers/api/repos_controller.rb
+++ b/app/controllers/api/repos_controller.rb
@@ -1,7 +1,15 @@
 class Api::ReposController < ApplicationController
     before_action :get_orgs, :check_org
-    def index
-      render json: { repositories: @organization.repositories}, status: :ok
+    def index      
+      repos = @organization.repositories
+      repos_json = JSON.parse(repos.to_json())
+
+      # add code_alerts_exist flag to repositories json
+      repos.zip(repos_json).each { |repo, repo_json|
+        repo_json["code_alerts_exist"] = repo.code_alerts.size() > 0
+      }
+
+      render json: { repositories: repos_json }, status: :ok
     end
 
     private


### PR DESCRIPTION
### Testing
Tested organizations and repositories with fake code_alerts; both worked
Did not test with more than 1 organization

### Changes
Organizations response: add "code_alerts_exist" field
Repositories response:   add "code_alerts" field